### PR TITLE
feat: configurable and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,16 @@ config.include CapybaraWatcher, type: :feature
 ...
 ```
 
+#### Configuring
+On your `rails_helper.rb`
+```ruby
+CapybaraWatcher.configure do |options|
+  options.timeout = 5 # Time in seconds
+end
+```
+
+> The timeout option has a default value of 2 (seconds), and this means that a when CapybaraWatcher wait more than this time, it automatically continue with the program.
+
 ## Built With
 
 * [Ruby](https://www.ruby-lang.org/es/) - A PROGRAMMER'S BEST FRIEND

--- a/lib/capybara_watcher.rb
+++ b/lib/capybara_watcher.rb
@@ -1,7 +1,13 @@
+require_relative './capybara_watcher/configuration'
+
 module CapybaraWatcher
+  def self.configure
+    yield Configuration.options
+  end
+
   def looped?
     # define N seconds to let test continue.
-    @seconds >= 4
+    @seconds >= Configuration.options[:timeout]
   end
 
   def wait_for_changes(repeat = 1)

--- a/lib/capybara_watcher/configuration.rb
+++ b/lib/capybara_watcher/configuration.rb
@@ -1,0 +1,15 @@
+module CapybaraWatcher
+  module Configuration
+    class << self
+      def options
+        @options ||= {
+          timeout: 2
+        }
+      end
+
+      def options=(options = nil)
+        @options = options unless options.nil?
+      end
+    end
+  end
+end


### PR DESCRIPTION
#4 
To do:
- [x] user can set timeout on configuration
- [x] set default timeout to 2 in `lib/capybara_watcher.rb`

_Example:_
```ruby
RSpec.configure do |c|
  c.include Helpers, timeout: 10
end
```

**Resource:** https://relishapp.com/rspec/rspec-core/docs/helper-methods/define-helper-methods-in-a-module